### PR TITLE
updated plugins and features in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
   ~
-  ~  Copyright 2016-2017 Red Hat, Inc, IBM, and individual contributors.
+  ~  Copyright 2016-2020 Red Hat, Inc, IBM, and individual contributors.
   ~
   ~  Licensed under the Apache License, Version 2.0 (the "License");
   ~  you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~
   ~  Copyright 2016-2017 Red Hat, Inc, IBM, and individual contributors.
@@ -35,10 +35,10 @@
         <version.arquillian-cube>1.18.2</version.arquillian-cube>
         <version.fabric8-maven-plugin>4.3.0</version.fabric8-maven-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
-        <version.restassured>4.1.1</version.restassured>       
+        <version.restassured>4.1.1</version.restassured>
         <version.openliberty.maven.plugin>3.2.4</version.openliberty.maven.plugin>
 
-         <fabric8.generator.from>docker.io/openliberty/open-liberty-s2i:19.0.0.9</fabric8.generator.from>   
+        <fabric8.generator.from>docker.io/openliberty/open-liberty-s2i:19.0.0.9</fabric8.generator.from>
     </properties>
 
     <!-- Specify the repositories containing RHOAR artifacts. -->
@@ -94,7 +94,7 @@
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- For tests -->
         <dependency>
             <groupId>junit</groupId>
@@ -149,7 +149,7 @@
             <artifactId>shrinkwrap-api</artifactId>
             <scope>test</scope>
         </dependency>
-    
+
         <!-- Support for JDK 9 and above -->
         <dependency>
             <groupId>javax.xml.bind</groupId>
@@ -192,11 +192,12 @@
                 <version>${version.openliberty.maven.plugin}</version>
 
                 <configuration>
-                   
+
                     <bootstrapProperties>
                         <default.http.port>${http.port}</default.http.port>
                         <default.https.port>${https.port}</default.https.port>
                         <app.context.root>/</app.context.root>
+                        <project.artifactId>${project.artifactId}</project.artifactId>
                     </bootstrapProperties>
                 </configuration>
                 <executions>
@@ -209,7 +210,7 @@
                             <goal>configure-arquillian</goal>
                             <goal>deploy</goal>
                         </goals>
-                    
+
                     </execution>
 
                     <execution>
@@ -219,7 +220,7 @@
                         </goals>
                         <configuration>
                             <packageName>rest-http-openliberty</packageName>
-                            <include>runnable</include>                            
+                            <include>runnable</include>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <version.fabric8-maven-plugin>4.3.0</version.fabric8-maven-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
         <version.restassured>4.1.1</version.restassured>       
-        <version.openliberty.maven.plugin>3.1</version.openliberty.maven.plugin>
+        <version.openliberty.maven.plugin>3.2.4</version.openliberty.maven.plugin>
 
          <fabric8.generator.from>docker.io/openliberty/open-liberty-s2i:19.0.0.9</fabric8.generator.from>   
     </properties>
@@ -90,16 +90,16 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.0</version>
+            <version>3.3</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         
         <!-- For tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,9 @@
         
         <!-- For tests -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/licenses/licenses.html
+++ b/src/licenses/licenses.html
@@ -2039,7 +2039,7 @@
     <tr>
       <td>org.eclipse.microprofile</td>
       <td>microprofile</td>
-      <td>3.0</td>
+      <td>3.3</td>
       <td>
         
         <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
@@ -2099,7 +2099,7 @@
     <tr>
       <td>org.eclipse.microprofile.health</td>
       <td>microprofile-health-api</td>
-      <td>2.0</td>
+      <td>2.2</td>
       <td>
         
         <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>

--- a/src/licenses/licenses.html
+++ b/src/licenses/licenses.html
@@ -939,7 +939,7 @@
     <tr>
       <td>junit</td>
       <td>junit</td>
-      <td>4.12</td>
+      <td>4.13.1</td>
       <td>
         
         <a href="http://repository.jboss.org/licenses/epl-1.0.txt">Eclipse Public License, Version 1.0</a>

--- a/src/licenses/licenses.xml
+++ b/src/licenses/licenses.xml
@@ -500,7 +500,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <licenses>
                 <license>
                     <name>Eclipse Public License, Version 1.0</name>

--- a/src/licenses/licenses.xml
+++ b/src/licenses/licenses.xml
@@ -1105,7 +1105,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.0</version>
+            <version>3.3</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1138,7 +1138,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
-            <version>2.0</version>
+            <version>2.2</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -1,14 +1,13 @@
 <server description="Open Liberty REST-0 example">
 
   <featureManager>
-      <feature>jaxrs-2.1</feature>
-      <!-- Required for Arquillian tests -->     
-      <feature>localConnector-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <!-- Required for Arquillian tests -->
+    <feature>localConnector-1.0</feature>
   </featureManager>
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
-                id="defaultHttpEndpoint" host="*" />
+  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint" host="*" />
 
-  <webApplication location="rest-http.war" contextRoot="${app.context.root}"/>
-   
+  <webApplication location="${project.artifactId}.war" contextRoot="${app.context.root}" />
+
 </server>


### PR DESCRIPTION
Updated features to LMP 3.2.4, mpHealth 2.2, microprofile 3.3, junit 4.13.1
### OpenJDK64-1.8.0
`Launching defaultServer (Open Liberty 20.0.0.10/wlp-1.0.45.cl201020200915-1100) on OpenJDK 64-Bit Server VM, version 1.8.0_265-b01 (en_CA)`

Upon running `mvn liberty:dev` there are no warnings.
Upon running `mvn verify` all seems well. Application runs normally.

### OpenJDK64-11.0.8
`Launching defaultServer (Open Liberty 20.0.0.10/wlp-1.0.45.cl201020200915-1100) on OpenJDK 64-Bit Server VM, version 11.0.8+10 (en_CA)`

Upon running `mvn liberty:dev` the following output appears:
``` 
warning: Supported source version 'RELEASE_8' from annotation processor 'org.kohsuke.metainf_services.AnnotationProcessorImpl' less than -source '11'
1 warning
```
Upon running `mvn verify` all seems well. Application runs normally.